### PR TITLE
[modify] modify watchmedo option name

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-xterm -e watchmedo tricks tricks.yml &
+xterm -e watchmedo tricks-from tricks.yml &
 


### PR DESCRIPTION
下記のようなエラーが発生するため，現在のwatchdogの仕様通りtricks-fromオプションを指定するよう変更しました．

vagrant@box:~/workspace/test-devrtbuild-pa10$ watchmedo tricks tricks.yml
usage: watchmedo [-h] [--version]
                 {tricks-from,tricks-generate-yaml,log,shell-command,auto-restart}
                 ...
watchmedo: error: invalid choice: 'tricks' (choose from 'tricks-from', 'tricks-generate-yaml', 'log', 'shell-command', 'auto-restart')
